### PR TITLE
指定領域だけを録画する

### DIFF
--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -19,7 +19,9 @@ export class Recorder {
     const sources = await desktopCapturer.getSources({ types: ['screen'] });
     console.log(sources)
     // TODO: ウィンドウ位置からスクリーンを自動で選択
-    const source = sources.filter(s => s.name === 'Screen 1').shift();
+    const source = sources.filter(
+      ({ name }) => name === 'Entire Screen' || name === 'Screen 1',
+    ).shift();
     if (!source) return;
 
     const screenStream = await navigator.mediaDevices.getUserMedia({


### PR DESCRIPTION
#2 ではスクリーン全体を録画したが、指定領域（このアプリのウィンドウの位置・サイズ）だけが録画されるように変更する。

動画の切り出し（crop）をするためには、

1. `video` 要素の `srcObject` に `MediaStream` を割り当て、動画を再生
2. 再生中の画像を `canvas` 要素に描画（フレームごとに繰り返す）
3. [`canvas.captureStream()`](https://developer.mozilla.org/ja/docs/Web/API/HTMLCanvasElement/captureStream) で `MediaStream` を取り出す

という手順を踏む必要がある様子。