### PR TITLE
録画内容を animated WebP に変換する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,10 +7,14 @@ const { Menu, getCurrentWebContents } = window.require('electron').remote;
 
 const App: React.FC = () => {
   const [recording, setRecording] = useState(false);
-  const recorder = useRef(new Recorder());
+  const recorder = useRef<Recorder | null>(null);
 
   useEffect(() => {
-    recording ? recorder.current.start() : recorder.current.stop();
+    if (recorder.current) {
+      recording ? recorder.current.start() : recorder.current.stop();
+    } else {
+      recorder.current = new Recorder();
+    }
 
     Menu.setApplicationMenu(
       Menu.buildFromTemplate([

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -83,13 +83,26 @@ export class Recorder {
     this.croppingCanvas.height = bounds.height;
     const ctx = this.croppingCanvas.getContext('2d')!;
 
+    let count = 0;
+    const dirName = path.join(
+      app.getPath('desktop'),
+      `recording_${format(new Date(), 'yyyy-MM-dd_HH-mm-ss')}`,
+    );
+    fs.mkdirSync(dirName);
+
     this.screenVideo.autoplay = true;
     this.screenVideo.srcObject = src;
     this.screenVideo.onplay = () => {
-      this.intervalId = window.setInterval(
-        () => ctx.drawImage(this.screenVideo, -bounds.x, -bounds.y),
-        1000 / this.frameRate,
-      );
+      this.intervalId = window.setInterval(() => {
+        ctx.drawImage(this.screenVideo, -bounds.x, -bounds.y);
+        this.croppingCanvas.toBlob(async blob => {
+          const data = await blobToUint8Array(blob!);
+          const fileName = `${count.toString().padStart(5, '0')}.png`;
+          fs.writeFileSync(path.join(dirName, fileName), data);
+          count++;
+          console.log(fileName);
+        }, 'image/png');
+      }, 1000 / this.frameRate);
       this.screenVideo.onplay = null;
     };
 

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -48,6 +48,7 @@ export class Recorder {
     const chunks: Blob[] = [];
     const mediaRecorder = new MediaRecorder(croppedStream, {
       mimeType: 'video/webm',
+      bitsPerSecond: 100 * 1000 * 1000,
     });
     mediaRecorder.ondataavailable = e => chunks.push(e.data);
     mediaRecorder.onstop = async e => {

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -8,7 +8,7 @@ const { app, getCurrentWindow, screen } = remote;
 export class Recorder {
   readonly screenVideo = document.createElement('video');
   readonly croppingCanvas = document.createElement('canvas');
-  readonly frameRate = 60;
+  readonly frameRate = 10;
 
   private mediaRecorder: MediaRecorder | null = null;
   private intervalId: number | null = null;


### PR DESCRIPTION
各フレームを一旦 PNG に保存し、それを WebP に変換する。

# 検討内容

## 変換方法

### A. WebM 動画から `ffmpeg` で WebP に変換

`MediaRecorder` で録画した WebM 動画を、`ffmpeg` で変換する。[ここ](https://evermeet.cx/ffmpeg/)のビルド済みバイナリ v4.2.1 を使用。

```sh
$ ffmpeg -i in.webm -loop 0 out.webp
```

[他のオプション](http://ffmpeg.org/ffmpeg-codecs.html#libwebp)も少し試してみたが、それほど変わらず。

ちなみに、`$ brew install ffmpeg` でインストールされる `ffmpeg` は libwepb つきでビルドされていないため、以下のエラーが出る。

> Automatic encoder selection failed for output stream #0:0. Default encoder for format webp (codec webp) is probably disabled. Please choose an encoder manually.

### B. 各フレームの PNG から `img2webp` で WebP に変換

WebP 公式が用意しているツール [`img2webp`](https://developers.google.com/speed/webp/docs/img2webp) を利用する。`$ brew install webp` でインストールされる（1.0.3 を使用）。

```sh
$ img2webp -lossless -d 100 *.png -o out.webp
```

`-lossy` をつけると、非可逆圧縮が行われる。

```sh
$ img2webp -lossy -d 100 *.png -o out.webp
```

## 結果の比較

800×600、10 fps、4 秒程度の小さな WebM 動画を変換した結果。

|変換方法|所要時間|出力サイズ|
|:--|--:|--:|
|A. `ffmpeg`|11.2 s|1,193 KiB|
|B1. `img2webp -lossless`|6.0 s|2,465 KiB|
|B2. `img2webp -lossy`|1.2 s| 710 KiB|

**B2. `img2webp -lossy` が時間・サイズともに優れている。** 非可逆圧縮だが、画質的にも特に問題なさそう。

A. `ffmpeg` も（[`webpinfo`](https://developers.google.com/speed/webp/docs/webpinfo) で確認する限り）非可逆圧縮だが、性能が悪い。前段階である WebM 動画へのエンコードにおいて、先に非可逆圧縮が掛かるため、それが障害要因になっていそう。

### 出力された WebP ファイル

<details>

<summary>クリックで表示</summary>

※ 拡張子が `.webp` だと GitHub に貼り付けられないので、`.gif` に偽装してアップロードした

A. `ffmpeg`
![ffmpeg webp](https://user-images.githubusercontent.com/6268183/68311252-a34d6500-00f4-11ea-8611-fd71d6b7271f.gif)

B1. `img2webp -lossless`
![img2webp_lossless webp](https://user-images.githubusercontent.com/6268183/68311103-6ed9a900-00f4-11ea-8b44-0e2c1e57b8d0.gif)

B2. `img2webp -lossy`
![img2webp_lossy webp](https://user-images.githubusercontent.com/6268183/68311072-5d909c80-00f4-11ea-80d6-00c2de9552b8.gif)

</details>