### PR TITLE
領域指定に react-image-crop を使う

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/node": "12.11.5",
     "@types/react": "16.9.9",
     "@types/react-dom": "16.9.2",
+    "@types/react-image-crop": "^8.1.2",
     "classnames": "^2.2.6",
     "date-fns": "^2.6.0",
     "electron": "^7.0.0",
@@ -22,6 +23,7 @@
     "prettier": "^1.18.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
+    "react-image-crop": "^8.4.0",
     "react-scripts": "3.2.0",
     "typescript": "3.6.4"
   },

--- a/src/App.css
+++ b/src/App.css
@@ -4,6 +4,11 @@
   background-color: transparent;
 }
 
+/* disabled 時（録画中は）ボーダーを消す */
+.ReactCrop--disabled .ReactCrop__crop-selection {
+  border: none;
+}
+
 /* ウィンドウ全体を crop 可能な領域にする */
 .CropTarget {
   width: 100vw;

--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,11 @@
-.App {
-  height: 100vh;
-  display: flex;
-  box-sizing: border-box;
-  align-items: center;
-  justify-content: center;
-  border: solid gray 2px;
+/* react-image-crop のスタイルを上書きする */
+.ReactCrop, .ReactCrop > div:first-child {
+  display: block;
+  background-color: transparent;
 }
 
-.App.recording {
-  border-color: magenta;
+/* ウィンドウ全体を crop 可能な領域にする */
+.CropTarget {
+  width: 100vw;
+  height: 100vh;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,20 +7,31 @@ import { updateMenu } from './menu';
 
 import './App.css';
 
+const cropToBounds = (crop: ReactCrop.Crop): Electron.Rectangle => ({
+  x: crop.x || 0,
+  y: crop.y || 0,
+  width: crop.width || 0,
+  height: crop.height || 0,
+});
+
 const App: React.FC = () => {
   const [recording, setRecording] = useState(false);
   const recorder = useRef<Recorder | null>(null);
+  const [crop, setCrop] = useState<ReactCrop.Crop>({});
 
   useEffect(() => {
     if (recorder.current) {
-      recording ? recorder.current.start() : recorder.current.stop();
+      recording
+        ? recorder.current.start(cropToBounds(crop))
+        : recorder.current.stop();
     } else {
       recorder.current = new Recorder();
     }
     updateMenu(recording, setRecording);
+    // recording を切り替えたときだけ実行したいので、crop は deps に含めない
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recording]);
 
-  const [crop, setCrop] = useState<ReactCrop.Crop>({});
   // renderComponent を使っていると crop の初期値が反映されない（crop が表示されない）ので、
   // マウントされた後に初期値を setCrop して表示させる
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,12 +20,18 @@ const App: React.FC = () => {
     updateMenu(recording, setRecording);
   }, [recording]);
 
-  const [crop, setCrop] = useState<ReactCrop.Crop>({
-    x: 300,
-    y: 300,
-    width: 300,
-    height: 200,
-  });
+  const [crop, setCrop] = useState<ReactCrop.Crop>({});
+  // renderComponent を使っていると crop の初期値が反映されない（crop が表示されない）ので、
+  // マウントされた後に初期値を setCrop して表示させる
+  useEffect(() => {
+    setCrop({
+      // TODO: 前回録画時の値を使う
+      x: 300,
+      y: 300,
+      width: 300,
+      height: 200,
+    });
+  }, []);
 
   return (
     <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
-import classnames from 'classnames';
 import React, { useState, useEffect, useRef } from 'react';
+import ReactCrop from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
+
 import { Recorder } from './recorder';
 import { updateMenu } from './menu';
 
@@ -18,7 +20,24 @@ const App: React.FC = () => {
     updateMenu(recording, setRecording);
   }, [recording]);
 
-  return <div className={classnames('App', recording && 'recording')} />;
+  const [crop, setCrop] = useState<ReactCrop.Crop>({
+    x: 300,
+    y: 300,
+    width: 300,
+    height: 200,
+  });
+
+  return (
+    <div>
+      <ReactCrop
+        src="" // renderComponent を表示するので不要だが、型の上では必須
+        renderComponent={<div className="CropTarget" />}
+        crop={crop}
+        onChange={setCrop}
+        keepSelection
+      />
+    </div>
+  );
 };
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ const App: React.FC = () => {
         renderComponent={<div className="CropTarget" />}
         crop={crop}
         onChange={setCrop}
+        disabled={recording}
         keepSelection
       />
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -5,5 +5,4 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-app-region: drag;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -10,14 +10,23 @@ let mainWindow;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
+    resizable: false,
+    movable: false,
+    alwaysOnTop: true,
     frame: false,
+    hasShadow: false,
     transparent: true,
     webPreferences: {
       nodeIntegration: true,
     },
   });
+
+  mainWindow.setVisibleOnAllWorkspaces(true, {
+    visibleOnFullScreen: true,
+  });
+
+  // TODO: ディスプレイが切り替わったらそのたびにフルスクリーン化
+  mainWindow.setSimpleFullScreen(true);
 
   mainWindow.loadURL(
     isDev

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,6 +1331,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-image-crop@^8.1.2":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-image-crop/-/react-image-crop-8.1.2.tgz#9c16d6b0b577a63a854a1a895180cc76800e2988"
+  integrity sha512-K6mbw1Bj/CeePnRa78E3v3gIn/EeqlCof5IVU9IPLdzMjOsf+ccn3Qv/vagsH/6eANGgoDz4hG41eJ2kggiuuw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.9.9":
   version "16.9.9"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.9.tgz#a62c6f40f04bc7681be5e20975503a64fe783c3a"
@@ -2649,6 +2656,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clsx@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
+  integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2900,6 +2912,11 @@ core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
+core-js@^3.3.3:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.1.tgz#76dd6828412900ab27c8ce0b22e6114d7ce21b18"
+  integrity sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -8568,6 +8585,15 @@ react-error-overlay@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==
+
+react-image-crop@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/react-image-crop/-/react-image-crop-8.4.0.tgz#48cba2a30f2a27a6a13afa5867843bdc8c6b8a1b"
+  integrity sha512-RYaWFrbC49ZPoC16n48oytCkJEMoXFIE6Kqo34NRp9+wRtNXDvtienppcIrrU/30WQfnY2tqhr3uXTYrNgEhXw==
+  dependencies:
+    clsx "^1.0.4"
+    core-js "^3.3.3"
+    prop-types "^15.7.2"
 
 react-is@^16.8.1, react-is@^16.8.4:
   version "16.10.1"


### PR DESCRIPTION
今まではウィンドウで代用していた（#4 参照）が、[react-image-crop](https://github.com/DominicTobias/react-image-crop) を使って操作性を上げる。

ウィンドウはフルスクリーン状態で最上面に表示させ、この上を自由に領域指定できるようにする。

ディスプレイやワークスペースの切り替えに対する考慮は後まわし。

## 領域指定 → 録画 の様子

![Kapture 2019-11-17 at 20 03 11](https://user-images.githubusercontent.com/6268183/69006677-a7d81000-0975-11ea-888c-86f091309743.gif)

## 上の録画結果

![cappi_2019-11-17_20-01-19 webp](https://user-images.githubusercontent.com/6268183/69006685-d81fae80-0975-11ea-80c5-a0ca44443121.gif)
